### PR TITLE
Update uuid package, import and calls (uuid->uuidv4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10264,6 +10264,11 @@
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -10969,6 +10974,11 @@
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -11903,9 +11913,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -12153,6 +12163,13 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "webpack-manifest-plugin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "react-dom": "^16.8.6",
     "react-scripts": "3.1.0",
     "use-combined-reducers": "^1.0.3",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import React, {
   useContext,
   createContext,
 } from 'react';
-import uuid from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 
 import useCombinedReducers from 'use-combined-reducers';
 
@@ -12,17 +12,17 @@ const DispatchContext = createContext(null);
 
 const initialTodos = [
   {
-    id: uuid(),
+    id: uuidv4(),
     task: 'Learn React',
     complete: true,
   },
   {
-    id: uuid(),
+    id: uuidv4(),
     task: 'Learn Firebase',
     complete: true,
   },
   {
-    id: uuid(),
+    id: uuidv4(),
     task: 'Learn GraphQL',
     complete: false,
   },
@@ -171,7 +171,7 @@ const AddTodo = () => {
 
   const handleSubmit = event => {
     if (task) {
-      dispatch({ type: 'ADD_TODO', task, id: uuid() });
+      dispatch({ type: 'ADD_TODO', task, id: uuidv4() });
     }
 
     setTask('');


### PR DESCRIPTION
This is the companion PR to https://github.com/rwieruch/blog_robinwieruch_content/pull/217.

Compilation doesn't fail here (app repo) like it does in the blog (content repo), because in this repo you hardcode `"uuid": "^3.3.2"` in [package.json](https://github.com/the-road-to-learn-react/react-with-redux-philosophy/blob/master/package.json#L10) and when using v3.3.2 you can use the legacy import and calls.

The trouble comes into view if you are not working with a cloned version of this repo and instead have a freshly bootstrapped project (using CRA), because in the [article](https://www.robinwieruch.de/react-state-usereducer-usestate-usecontext) there is the instruction:

> First, you can install it on the command line:
`npm install uuid`

Doing this will result in the latest version of `uuid` being installed, which is `8.3.2` currently. 

This version will break the compilation if you aren't using the updated import and call syntax (or change the instruction to install uuid with `npm install uuid@3.3.2`). 

This is kind of minor, but annoying when following along with the article, because this seems to be the only dependency that has an issue. 

